### PR TITLE
Fix cli compilation path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ changelog/add:
 	@echo " END $(CL_REMINDERS_COMMENT) -->" >> "$(CURR_VERSION_CL)"
 	@$(EDITOR) "$(CURR_VERSION_CL)"
 	@$(MAKE) changelog
-	@git add CHANGELOG.md "$(CURR_VERSION_CL)" && git commit -em "update changelog for v$(CURR_VERSION)" && \
+	@git add CHANGELOG.md "$(CURR_VERSION_CL)" && git commit -m "update changelog for v$(CURR_VERSION)" && \
 		echo "==> Changelog updated and committed, thanks for keeping it up-to-date!"
 
 .PHONY: debug/docs

--- a/action.yml
+++ b/action.yml
@@ -84,8 +84,12 @@ runs:
       with:
         go-version: 1.18
 
+    # Compile the CLI inline. We should work to remove this step by using
+    # precompiled binaries for tagged versions (maybe stored as release
+    # assets).
     - name: Compile the CLI
       shell: bash
+      working-directory: ${{ github.action_path }}
       run: make cli
 
     # Digest inputs and context.


### PR DESCRIPTION
### Justification

This fixes an issue where the built CLI was in the wrong path for workflows referencing the action by version (as opposed to locally on the same branch).

### Summary

Run `make cli` in `github.action_path` rather than in the checked out repo path.

Also addresses a review comment from #3 where we were opening the editor for all changelog commits which might not be needed.

### Quality

  - [ ] Previously broken tests are fixed.