### PR TITLE
Fix hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,10 @@ endif
 
 RUN_TESTS_QUIET := @$(MAKE) test > /dev/null 2>&1 || { echo "Tests failed, please run 'make test'."; exit 1; }
 
-# Always just install the git hooks.
+# Always just install the git hooks unless in CI (GHA sets CI=true as do many CI providers).
+ifeq ($(CI),true)
 _ := $(shell mkdir -p .git/hooks && cd .git/hooks && ln -fs ../../dev/git_hooks/* .)
+endif
 
 ifneq ($(PRODUCT_VERSION),)
 CURR_VERSION := $(PRODUCT_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ endif
 RUN_TESTS_QUIET := @$(MAKE) test > /dev/null 2>&1 || { echo "Tests failed, please run 'make test'."; exit 1; }
 
 # Always just install the git hooks.
-_ := $(shell cd .git/hooks && ln -fs ../../dev/git_hooks/* .)
+_ := $(shell mkdir -p .git/hooks && cd .git/hooks && ln -fs ../../dev/git_hooks/* .)
 
 ifneq ($(PRODUCT_VERSION),)
 CURR_VERSION := $(PRODUCT_VERSION)

--- a/dev/git_hooks/pre-push
+++ b/dev/git_hooks/pre-push
@@ -68,15 +68,9 @@ if [[ "${DEBUG:-}" == "1" ]]; then
 		echo "$OUT"
 		return $X
 	}
-	grep() {
-		$(which grep) -E "$@"
-	}
 else
 	run_log() {
 		"$@"
-	}
-	grep() {
-		$(which grep) -Eq "$@"
 	}
 fi
 
@@ -84,21 +78,16 @@ changed_files() {
 	git diff --name-only "$range"
 }
 
-changed_files_include() {
-	local PATTERN="$1"
-	run_log changed_files | "$GREP" "^$PATTERN\$"
-}
-
 changed_go_files() {
-	run_log changed_files | grep '.*\.go$'
+	run_log changed_files | grep -E '.*\.go$'
 }
 
 go_implementation_changed() {
-	run_log changed_go_files | grep -v '_test\.go$'
+	run_log changed_go_files | grep -Eqv '_test\.go$'
 }
 
 go_tests_changed() {
-	run_log changed_files | grep '_test\.go$'
+	run_log changed_go_files | grep -Eq '_test\.go$'
 }
 
 should_have_changelog_update() {


### PR DESCRIPTION
### Justification

Main is currently broken due to a problem installing git hooks.

### Summary

Fixes the proximate cause (missing .git/hooks directory) and also stops trying to install the hooks in CI since they're not appropriate there anyway. Also tweaks the hook slightly to make it easier to read (no longer overriding grep with a function).

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [x] Changes only in dev tooling.