### PR TITLE
detect installed go version correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Instead, edit the files in dev/changes/, then run 'make docs' to update this fil
 
 ## Unreleased Changes (targeting v0.1.5)
 
-
+- Fix detection of Go version. Don't assume it's the same as the version that built
+  actions-go-build itself.
 
 ## [v0.1.4](https://github.com/hashicorp/actions-go-build/releases/tag/v0.1.4) - September 29, 2022
 

--- a/dev/changes/v0.1.5.md
+++ b/dev/changes/v0.1.5.md
@@ -1,0 +1,2 @@
+- Fix detection of Go version. Don't assume it's the same as the version that built
+  actions-go-build itself.

--- a/pkg/build/parameters.go
+++ b/pkg/build/parameters.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"fmt"
+	"os/exec"
 	"runtime"
 	"strings"
 
@@ -34,9 +35,20 @@ func (bp Parameters) trimSpace() Parameters {
 	return bp
 }
 
+func getInstalledGoVersion() (string, error) {
+	got, err := exec.Command("go", "env", "GOVERSION").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(string(got[:len(got)-1]), "go"), nil
+}
+
 func (bp Parameters) setDefaults(p crt.Product) (Parameters, error) {
 	if bp.GoVersion == "" {
-		bp.GoVersion = strings.TrimPrefix(runtime.Version(), "go")
+		var err error
+		if bp.GoVersion, err = getInstalledGoVersion(); err != nil {
+			return bp, err
+		}
 	}
 	if bp.OS == "" {
 		bp.OS = runtime.GOOS

--- a/pkg/build/parameters.go
+++ b/pkg/build/parameters.go
@@ -40,7 +40,14 @@ func getInstalledGoVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimPrefix(string(got[:len(got)-1]), "go"), nil
+	return parseGoVersion(string(got)), nil
+}
+
+func parseGoVersion(raw string) string {
+	raw = strings.TrimPrefix(raw, "go")
+	raw = strings.TrimPrefix(raw, "v")
+	raw = strings.TrimSuffix(raw, "\n")
+	return raw
 }
 
 func (bp Parameters) setDefaults(p crt.Product) (Parameters, error) {

--- a/pkg/build/parameters_test.go
+++ b/pkg/build/parameters_test.go
@@ -1,0 +1,37 @@
+package build
+
+import (
+	"testing"
+)
+
+func TestParseGoVersion(t *testing.T) {
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"1.14", "1.14"},
+		{"1.14\n", "1.14"},
+		{"v1.14", "1.14"},
+		{"v1.14\n", "1.14"},
+		{"go1.14", "1.14"},
+		{"go1.14\n", "1.14"},
+		{"1.18", "1.18"},
+		{"1.18\n", "1.18"},
+		{"v1.18", "1.18"},
+		{"v1.18\n", "1.18"},
+		{"go1.18", "1.18"},
+		{"go1.18\n", "1.18"},
+	}
+
+	for _, c := range cases {
+		in, want := c.in, c.want
+		t.Run(in, func(t *testing.T) {
+			got := parseGoVersion(in)
+			if got != want {
+				t.Errorf("got %q=>%q; want %q", in, got, want)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
- Don't assume it's the same as the version that built actions-go-build itself.

Without this builds for versions < 1.18 fail because the set of command line flags passed to go is not compatible.