### PR TITLE
Record test output in quiet mode, display on failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,7 @@ env:
 
 .PHONY: $(TMP_BUILD)
 $(TMP_BUILD):
+	# Running tests...
 	@$(RUN_TESTS_QUIET)
 	@echo "# Creating temporary build." 1>&2
 	@rm -f "$(TMP_BUILD)"
@@ -91,8 +92,6 @@ $(TMP_BUILD):
 .PHONY: $(CLI)
 $(CLI):
 	@$(CLEAR)
-	# Running tests...
-	@$(RUN_TESTS_QUIET)
 	# First build:   Plain go build...
 	@$(MAKE) $(TMP_BUILD)
 	# Second build:  Using first build to build self...

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SHELL := /usr/bin/env bash -euo pipefail -c
 
 PRODUCT_NAME := actions-go-build
+DESTDIR ?= /usr/local/bin
 
 # Set AUTOCLEAR=1 to have the terminal cleared before running builds,
 # tests, and installs.
@@ -114,9 +115,9 @@ install: $(CLI)
 else
 install: $(CLI)
 	@$(CLEAR)
-	@mv "$<" /usr/local/bin/
+	@mv "$<" "$(DESTDIR)"
 	@V="$$($(CLINAME) version -short)" && \
-		echo "# $(CLINAME) v$$V installed to /usr/local/bin"
+		echo "# $(CLINAME) v$$V installed to $(DESTDIR)"
 endif
 
 .PHONY: mod/framework/update

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ ifeq ($(TMPDIR),)
 $(error Neither TMPDIR nor RUNNER_TEMP are set.)
 endif
 
-RUN_TESTS_QUIET := @$(MAKE) test > /dev/null 2>&1 || { echo "Tests failed, please run 'make test'."; exit 1; }
+TEST_LOG := $(TMPDIR)/go_tests.log
+RUN_TESTS_QUIET := @$(MAKE) test > "$(TEST_LOG)" 2>&1 || { cat "$(TEST_LOG)" ; exit 1; }
 
 # Always just install the git hooks unless in CI (GHA sets CI=true as do many CI providers).
 ifeq ($(CI),true)


### PR DESCRIPTION
### Justification

Failure discussed in [this slack thread](https://hashicorp.slack.com/archives/CR024M999/p1666297967882959)

### Summary

It's hard to diagnose failures in CI that don't happen locally.  This PR saves the output from the test suite run during `make install` and displays it if the tests fail, hopefully allowing easier diagnosis of the underlying problem.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [x] New or updated behavior which has been manually tested.  (I ran `make dist/actions-build-go` while `||` was changed to `&&` to verify that the logs would be dumped even though the tests all pass when I run the suite locally.)