### PR TITLE
Release builds prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 dist/
 out/
 meta/
+actions-go-build

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,11 +11,17 @@ so it can be used as a regular part of the day-to-day development of application
 Some things you might want to use the tool for when working locally.
 
 ```shell
-# Check that the project I'm currently working on is reproducible.
+# Just build the `main` package in the current directory.
+$ actions-go-build build
+
+# Check that the `main` package in the current directory is reproducible.
 $ actions-go-build verify
 
-# Just build the project I'm currently working on.
-$ actions-go-build build
+# Build the `main` package in ./cmd/product1
+$ actions-go-build build ./cmd/product1
+
+# Check that the `main` package in ./cmd/product1 is reproducible.
+$ actions-go-build verify ./cmd/product1
 
 # Export a build result json file for the project I'm working on.
 $ actions-go-build build -o my.buildresult.json

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,9 @@ type Config struct {
 	// Debug enables debug logging.
 	Debug bool `env:"DEBUG"`
 
+	// TargetDir can be used to override the primary target dir.
+	TargetDir string `env:"TARGET_DIR"`
+
 	Primary      Paths `env:",prefix=PRIMARY_"`
 	Verification Paths `env:",prefix=VERIFICATION_"`
 
@@ -50,6 +53,8 @@ type Paths struct {
 	// BuildRoot is the absolute path where the instructions are run for this build.
 	// We read it from the environment only to support testing.
 	BuildRoot string `env:"BUILD_ROOT"`
+	// TargetDir can be used to overwrite the target output directory.
+	TargetDir string `env:"TARGET_DIR"`
 	// BuildResult is the absolute path where the build result will be written.
 	// This is the same as the cache path for that build result.
 	// We do not read BuildResult from the environment.
@@ -76,7 +81,10 @@ func FromEnvironment(creator crt.Tool, dir string) (Config, error) {
 // buildConfig returns a BuildConfig based on this Config, rooted at root.
 // The root must be an absolute path.
 func (c Config) buildConfig(root string) (build.Config, error) {
-	paths, err := build.NewBuildPaths(root, c.Product.ExecutableName, c.Parameters.ZipName)
+	// If c.TargetDir is empty here then this option is a no-op,
+	// we just pass it through rather than wrapping in a conditional.
+	opts := build.WithTargetDir(c.TargetDir)
+	paths, err := build.NewBuildPaths(root, c.Product.ExecutableName, c.Parameters.ZipName, opts)
 	if err != nil {
 		return build.Config{}, err
 	}

--- a/internal/config/envvars_test.go
+++ b/internal/config/envvars_test.go
@@ -37,7 +37,6 @@ func TestConfig_BuildConfig_ok(t *testing.T) {
 			"/blah",
 			testBuildConfig(func(bc *build.Config) {
 				bc.Paths.WorkDir = "/blah"
-				bc.Paths.TargetDir = "/blah/dist"
 				bc.Paths.BinPath = "/blah/dist/lockbox"
 				bc.Paths.ZipPath = "/blah/out/lockbox_1.2.3_linux_amd64.zip"
 				bc.Paths.MetaDir = "/blah/meta"
@@ -51,7 +50,6 @@ func TestConfig_BuildConfig_ok(t *testing.T) {
 			"/blah",
 			testBuildConfig(func(bc *build.Config) {
 				bc.Paths.WorkDir = "/blah"
-				bc.Paths.TargetDir = "/blah/dist"
 				bc.Paths.BinPath = "/blah/dist/lockbox"
 				bc.Paths.ZipPath = "/blah/out/blargle.zip"
 				bc.Paths.MetaDir = "/blah/meta"
@@ -77,11 +75,10 @@ func standardBuildconfig() build.Config {
 		Product:    standardProduct(),
 		Parameters: standardParameters(),
 		Paths: build.Paths{
-			WorkDir:   "/",
-			TargetDir: "/dist",
-			BinPath:   "/dist/lockbox",
-			ZipPath:   "/out/lockbox_1.2.3_linux_amd64.zip",
-			MetaDir:   "/meta",
+			WorkDir: "/",
+			BinPath: "/dist/lockbox",
+			ZipPath: "/out/lockbox_1.2.3_linux_amd64.zip",
+			MetaDir: "/meta",
 		},
 		Tool: crt.Tool{
 			Name:     "<tool-name>",

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -121,18 +121,18 @@ func (b *core) Steps() []Step {
 		newStep("asserting executable written", b.assertExecutableWritten),
 
 		newStep("setting mtimes", func() error {
-			return fs.SetMtimes(b.Config().Paths.TargetDir, productRevisionTimestamp)
+			return fs.SetMtimes(b.Config().Paths.TargetDir(), productRevisionTimestamp)
 		}),
 
 		newStep(fmt.Sprintf("creating zip file %q", b.Config().Paths.ZipPath), func() error {
-			return zipper.ZipToFile(b.Config().Paths.TargetDir, b.Config().Paths.ZipPath, b.Settings.Log)
+			return zipper.ZipToFile(b.Config().Paths.TargetDir(), b.Config().Paths.ZipPath, b.Settings.Log)
 		}),
 	}
 }
 
 func (b *core) createDirectories() error {
 	c := b.config
-	return fs.Mkdirs(c.Paths.TargetDir, c.Paths.ZipDir(), c.Paths.MetaDir)
+	return fs.Mkdirs(c.Paths.TargetDir(), c.Paths.ZipDir(), c.Paths.MetaDir)
 }
 
 func (b *core) assertExecutableWritten() error {

--- a/pkg/build/env.go
+++ b/pkg/build/env.go
@@ -87,7 +87,7 @@ func BuildSpecificBuildEnvDefinitions() []EnvVar {
 		{
 			"TARGET_DIR",
 			"Absolute path to the zip contents directory.",
-			func(c Config) string { return c.Paths.TargetDir },
+			func(c Config) string { return c.Paths.TargetDir() },
 		},
 		{
 			"BIN_PATH",

--- a/pkg/build/paths.go
+++ b/pkg/build/paths.go
@@ -21,9 +21,6 @@ func (ds DirNames) List() []string {
 type Paths struct {
 	// WorkDir is the absolute directory to run the build instructions in.
 	WorkDir string
-	// TargetDir is the absolute path to the dir where any other files
-	// needed to be included in the zip file should be placed.
-	TargetDir string
 	// BinPath is the absolute path to the executable binary the instructions
 	// must create.
 	BinPath string
@@ -33,16 +30,45 @@ type Paths struct {
 	MetaDir string
 }
 
-func NewBuildPaths(root, executableName, zipName string) (Paths, error) {
+type pathsSettings struct {
+	// targetDir is used to calculate the default bin path.
+	targetDir string
+}
+
+// buildPathsSettings contains optional settings for build paths.
+type buildPathsSettings struct {
+	targetDir string
+}
+
+type BuildPathsOpt func(s *pathsSettings)
+
+func WithTargetDir(path string) BuildPathsOpt {
+	return func(s *pathsSettings) { s.targetDir = path }
+}
+
+func NewBuildPaths(root, executableName, zipName string, opts ...BuildPathsOpt) (Paths, error) {
 	var bp Paths
 	if !filepath.IsAbs(root) {
 		return bp, fmt.Errorf("root path %q is not absolute", root)
 	}
-	return bp.setDefaults(root, executableName, zipName), nil
+
+	settings := pathsSettings{}
+	// Apply options.
+	for _, o := range opts {
+		o(&settings)
+	}
+
+	return bp.setDefaults(root, executableName, zipName, settings), nil
 }
 
 func (bp Paths) ZipDir() string {
 	return filepath.Dir(bp.ZipPath)
+}
+
+// TargetDir is the absolute path to the dir where any other files
+// needed to be included in the zip file should be placed.
+func (bp Paths) TargetDir() string {
+	return filepath.Dir(bp.BinPath)
 }
 
 func (bp Paths) trimSpace() Paths {
@@ -50,11 +76,22 @@ func (bp Paths) trimSpace() Paths {
 	return bp
 }
 
-func (bp Paths) setDefaults(root, executableName, zipName string) Paths {
-	bp.WorkDir = root
-	bp.TargetDir = filepath.Join(root, Dirs.Target)
-	bp.BinPath = filepath.Join(root, Dirs.Target, executableName)
-	bp.ZipPath = filepath.Join(root, Dirs.Zip, zipName)
-	bp.MetaDir = filepath.Join(root, Dirs.Meta)
+func (bp Paths) setDefaults(root, executableName, zipName string, s pathsSettings) Paths {
+	if len(bp.WorkDir) == 0 {
+		bp.WorkDir = root
+	}
+	// Set the internal targetDir if it wasn't already set by an option.
+	if len(s.targetDir) == 0 {
+		s.targetDir = filepath.Join(bp.WorkDir, Dirs.Target)
+	}
+	if len(bp.BinPath) == 0 {
+		bp.BinPath = filepath.Join(s.targetDir, executableName)
+	}
+	if len(bp.ZipPath) == 0 {
+		bp.ZipPath = filepath.Join(bp.WorkDir, Dirs.Zip, zipName)
+	}
+	if len(bp.MetaDir) == 0 {
+		bp.MetaDir = filepath.Join(bp.WorkDir, Dirs.Meta)
+	}
 	return bp
 }

--- a/pkg/build/runner_test.go
+++ b/pkg/build/runner_test.go
@@ -134,11 +134,10 @@ func standardConfig(workDir string) Config {
 			Arch:         "amd64",
 		},
 		Paths: Paths{
-			WorkDir:   workDir,
-			TargetDir: filepath.Join(workDir, "dist"),
-			BinPath:   filepath.Join(workDir, "dist", "lockbox"),
-			ZipPath:   filepath.Join(workDir, "out", "lockbox_1.2.3_amd64.zip"),
-			MetaDir:   filepath.Join(workDir, "meta"),
+			WorkDir: workDir,
+			BinPath: filepath.Join(workDir, "dist", "lockbox"),
+			ZipPath: filepath.Join(workDir, "out", "lockbox_1.2.3_amd64.zip"),
+			MetaDir: filepath.Join(workDir, "meta"),
 		},
 	}
 }

--- a/pkg/commands/testdata/example.buildresult.json
+++ b/pkg/commands/testdata/example.buildresult.json
@@ -24,7 +24,6 @@
     },
     "Paths": {
       "WorkDir": "/Users/sam/src/github.com/hashicorp/actions-go-build",
-      "TargetDir": "/Users/sam/src/github.com/hashicorp/actions-go-build/dist",
       "BinPath": "/Users/sam/src/github.com/hashicorp/actions-go-build/dist/actions-go-build",
       "ZipPath": "/Users/sam/src/github.com/hashicorp/actions-go-build/out/actions-go-build_0.1.4_darwin_arm64.zip",
       "MetaDir": "/Users/sam/src/github.com/hashicorp/actions-go-build/meta"

--- a/run
+++ b/run
@@ -1,5 +1,25 @@
 #!/usr/bin/env bash
 
+# This script builds the CLI and runs the command you pass.
+#
+# When you're making changes to the CLI, it is often useful to quickly run
+# a command against your local development version to check that it's behaving
+# roughly as you expect. That's the main purpose of this script.
+#
+# We also use this script when generating documentation (e.g. for the README).
+# By running the CLI program and getting its output we can ensure that certain
+# parts of the README do not go out of date with respect to the code itself.
+#
+# By default this script prints the command to be run before running it.
+# You can suppress this by passing the -q flag.
+#
+# Usage Examples:
+#   
+#   ./run version            # Compile the CLI and run the version subcommand.
+#   ./run build -rebuild     # Compile the CLI and run the build command with the -rebuild flag.
+#   ./run -q build -rebuild  # Same as above but without printing the command itself.
+#   ./run -q inspect -describe-build-env  # Example actually in use for generating docs.
+
 set -Eeuo pipefail
 
 if [[ "${1:-}" == "-q" ]]; then

--- a/verify/testdata/valid-clean-non-reproducible-binary.buildresult.json
+++ b/verify/testdata/valid-clean-non-reproducible-binary.buildresult.json
@@ -24,7 +24,6 @@
     },
     "Paths": {
       "WorkDir": "/Users/sam/src/github.com/hashicorp/actions-go-build",
-      "TargetDir": "/Users/sam/src/github.com/hashicorp/actions-go-build/dist",
       "BinPath": "/Users/sam/src/github.com/hashicorp/actions-go-build/dist/actions-go-build",
       "ZipPath": "/Users/sam/src/github.com/hashicorp/actions-go-build/out/actions-go-build_0.1.4_darwin_arm64.zip",
       "MetaDir": "/Users/sam/src/github.com/hashicorp/actions-go-build/meta"

--- a/verify/testdata/valid-clean-non-reproducible-zip.buildresult.json
+++ b/verify/testdata/valid-clean-non-reproducible-zip.buildresult.json
@@ -24,7 +24,6 @@
     },
     "Paths": {
       "WorkDir": "/Users/sam/src/github.com/hashicorp/actions-go-build",
-      "TargetDir": "/Users/sam/src/github.com/hashicorp/actions-go-build/dist",
       "BinPath": "/Users/sam/src/github.com/hashicorp/actions-go-build/dist/actions-go-build",
       "ZipPath": "/Users/sam/src/github.com/hashicorp/actions-go-build/out/actions-go-build_0.1.4_darwin_arm64.zip",
       "MetaDir": "/Users/sam/src/github.com/hashicorp/actions-go-build/meta"

--- a/verify/testdata/valid-clean-reproducible.buildresult.json
+++ b/verify/testdata/valid-clean-reproducible.buildresult.json
@@ -24,7 +24,6 @@
     },
     "Paths": {
       "WorkDir": "/Users/sam/src/github.com/hashicorp/actions-go-build",
-      "TargetDir": "/Users/sam/src/github.com/hashicorp/actions-go-build/dist",
       "BinPath": "/Users/sam/src/github.com/hashicorp/actions-go-build/dist/actions-go-build",
       "ZipPath": "/Users/sam/src/github.com/hashicorp/actions-go-build/out/actions-go-build_0.1.4_darwin_arm64.zip",
       "MetaDir": "/Users/sam/src/github.com/hashicorp/actions-go-build/meta"

--- a/verify/testdata/valid-dirty-reproducible.buildresult.json
+++ b/verify/testdata/valid-dirty-reproducible.buildresult.json
@@ -24,7 +24,6 @@
     },
     "Paths": {
       "WorkDir": "/Users/sam/src/github.com/hashicorp/actions-go-build",
-      "TargetDir": "/Users/sam/src/github.com/hashicorp/actions-go-build/dist",
       "BinPath": "/Users/sam/src/github.com/hashicorp/actions-go-build/dist/actions-go-build",
       "ZipPath": "/Users/sam/src/github.com/hashicorp/actions-go-build/out/actions-go-build_0.1.4_darwin_arm64.zip",
       "MetaDir": "/Users/sam/src/github.com/hashicorp/actions-go-build/meta"


### PR DESCRIPTION
See [this slack thread](https://hashicorp.slack.com/archives/G01ETP58BL1/p1668014924591489?thread_ts=1667937471.536799&cid=G01ETP58BL1) (private link).

This PR puts in the groundwork for being able to produce release builds of the CLI for multiple target platforms. This is required so that users can obtain the CLI for local usage without having to clone and build this repository.

It refactors the Makefile so that `GOOS` and `GOARCH` can be set to something other than the host platform for the `make cli` target, whilst ensuring they are still set for the host platform for the tests, the initial temporary build and the intermediate build.

To enable this refactoring, you can now specify `TARGET_DIR` when running `actions-go-build build` in order to write the built _binary_ to a specific location. This will also be useful when creating release builds from the `release.yml` workflow, which will be updated in a follow-up PR.

- add actions-go-build to .gitignore
- allow setting TARGET_PATH for primary builds
- refactor makefile to prep for release builds
