### PR TITLE
add note to update actions/setup-go to use v3 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ _This is intended for internal HashiCorp use only; Internal folks please refer t
 This Action can run on both Ubuntu and macOS runners.
 
 The core functionality is contained in a Go CLI, which you can also install and
-use locally. See [the CLI docs](docs/cli.md) for local usage.
+use locally. See [the CLI docs](docs/cli.md) for local usage. Ensure that [actions/setup-go](https://github.com/actions/setup-go)
+is pointed to use the `v3` tag. Go version compiliation errors will appear if the `v2` tag is used. 
 
 ### Examples
 


### PR DESCRIPTION
### Justification / Summary

@emilymianeil and I were running into Go compilation [errors](https://github.com/hashicorp/consul/actions/runs/3585898049/jobs/6034457960) and it was found that using the v3 tag of actions/setup-go resolved this issue. This PR adds a note in the README file to encourage folks to update the tag when using this action. 

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [x] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_