### PR TITLE
RELENG-193: Replace ::set-output in GHA workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - id: get-version
-        run: VERSION="$(make version)" && echo "::set-output name=version::$VERSION"
+        run: VERSION="$(make version)" && echo "version=$VERSION" >> $GITHUB_OUTPUT
       - name: Release ${{ steps.get-version.outputs.version }}
         run: make release


### PR DESCRIPTION
Replace use of the now-deprecated set-output directive in GHA workflows with writes to the special $GITHUB_OUTPUT file.