### PR TITLE
Bshore/smre 177 node20 update

### DIFF
--- a/.github/workflows/self-test-suite-verify.yml
+++ b/.github/workflows/self-test-suite-verify.yml
@@ -31,9 +31,12 @@ jobs:
           - { assert: failure, file: corrupt,                             when: result file is corrupt }
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      # generate a random ID; GH doesn't provide a proper job ID (especially for matrix jobs)
+      - name: Generate random ID to distinguish build artifacts
+        run: echo "ARTIFACT_ID=$RANDOM" >> "$GITHUB_ENV"
       - uses: ./verify/self-test
         with:
           assert: ${{ matrix.assert }}
           when: ${{ matrix.when }}
           result_file: verify/testdata/${{ matrix.file }}.buildresult.json
-          output_file: verification-result-${{ inputs.runner }}.json
+          output_file: verification-result-${{ inputs.runner }}-${{ env.ARTIFACT_ID }}.json

--- a/.github/workflows/self-test-suite.yml
+++ b/.github/workflows/self-test-suite.yml
@@ -33,9 +33,12 @@ jobs:
           - { reproducible: nope,   want: success }
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: select OS value
+        run: case "${{ runner.os }}" in macOS) echo "SELECTED_OS=darwin" >> "$GITHUB_ENV" ;; Linux) echo "SELECTED_OS=linux" >> "$GITHUB_ENV" ;; esac
       - uses: ./self-test
         with:
           product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
+          os: ${{ env.SELECTED_OS }}
           reproducible: ${{ matrix.reproducible }}
           assert: ${{ matrix.want }}
           when: "the binary files are identical and there are no other files in the zip"
@@ -55,9 +58,12 @@ jobs:
           - { reproducible: nope,   want: success }
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: select OS value
+        run: case "${{ runner.os }}" in macOS) echo "SELECTED_OS=darwin" >> "$GITHUB_ENV" ;; Linux) echo "SELECTED_OS=linux" >> "$GITHUB_ENV" ;; esac
       - uses: ./self-test
         with:
           product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
+          os: ${{ env.SELECTED_OS }}
           reproducible: ${{ matrix.reproducible }}
           assert: ${{ matrix.want }}
           when: "the binary files are identical and so are two other files in the zip"
@@ -112,9 +118,12 @@ jobs:
           - { reproducible: nope,   want: success }
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: select OS value
+        run: case "${{ runner.os }}" in macOS) echo "SELECTED_OS=darwin" >> "$GITHUB_ENV" ;; Linux) echo "SELECTED_OS=linux" >> "$GITHUB_ENV" ;; esac
       - uses: ./self-test
         with:
           product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
+          os: ${{ env.SELECTED_OS }}
           reproducible: ${{ matrix.reproducible }}
           assert: ${{ matrix.want }}
           when: "the binary files reproduce but the zip files do not"
@@ -136,9 +145,12 @@ jobs:
           - { reproducible: nope,   want: success }
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: select OS value
+        run: case "${{ runner.os }}" in macOS) echo "SELECTED_OS=darwin" >> "$GITHUB_ENV" ;; Linux) echo "SELECTED_OS=linux" >> "$GITHUB_ENV" ;; esac
       - uses: ./self-test
         with:
           product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
+          os: ${{ env.SELECTED_OS }}
           reproducible: ${{ matrix.reproducible }}
           assert: ${{ matrix.want }}
           when: "neither the binary file not the zip file reproduce"
@@ -159,9 +171,12 @@ jobs:
           - { reproducible: nope,   want: failure }
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: select OS value
+        run: case "${{ runner.os }}" in macOS) echo "SELECTED_OS=darwin" >> "$GITHUB_ENV" ;; Linux) echo "SELECTED_OS=linux" >> "$GITHUB_ENV" ;; esac
       - uses: ./self-test
         with:
           product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
+          os: ${{ env.SELECTED_OS }}
           reproducible: ${{ matrix.reproducible }}
           assert: ${{ matrix.want }}
           when: "the binary file is not written to the correct path"

--- a/.github/workflows/self-test-suite.yml
+++ b/.github/workflows/self-test-suite.yml
@@ -17,6 +17,10 @@ jobs:
   # with different sets of inputs, and assert that the action succeeds or
   # fails correctly.
 
+  # Each test uses a distinct product_name that must account for both the job name
+  # and the variants introduced via job matrix in order to avoid duplicate artifact
+  # names (which cannot be uploaded as of actions/upload-artifact@v4.
+
   # A single reproducible go binary.
   ok-single-file:
     runs-on: ${{ inputs.runner }}
@@ -31,6 +35,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: ./self-test
         with:
+          product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
           reproducible: ${{ matrix.reproducible }}
           assert: ${{ matrix.want }}
           when: "the binary files are identical and there are no other files in the zip"
@@ -52,6 +57,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: ./self-test
         with:
+          product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
           reproducible: ${{ matrix.reproducible }}
           assert: ${{ matrix.want }}
           when: "the binary files are identical and so are two other files in the zip"
@@ -84,6 +90,7 @@ jobs:
       - uses: ./self-test
         if: runner.os == 'macOS'
         with:
+          product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
           os: ${{ matrix.os }}
           arch: ${{ matrix.arch }}
           reproducible: ${{ matrix.reproducible }}
@@ -107,6 +114,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: ./self-test
         with:
+          product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
           reproducible: ${{ matrix.reproducible }}
           assert: ${{ matrix.want }}
           when: "the binary files reproduce but the zip files do not"
@@ -130,6 +138,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: ./self-test
         with:
+          product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
           reproducible: ${{ matrix.reproducible }}
           assert: ${{ matrix.want }}
           when: "neither the binary file not the zip file reproduce"
@@ -152,6 +161,7 @@ jobs:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: ./self-test
         with:
+          product_name: "example-app-${{ github.job }}-${{ matrix.reproducible }}"
           reproducible: ${{ matrix.reproducible }}
           assert: ${{ matrix.want }}
           when: "the binary file is not written to the correct path"

--- a/self-test/action.yml
+++ b/self-test/action.yml
@@ -62,7 +62,7 @@ runs:
       id: build
       uses: ./ # The action at the root of this repo.
       with:
-        product_name: ${{ inputs.product_name }}_${{ github.job }}
+        product_name: ${{ inputs.product_name }}
         product_version: ${{ inputs.product_version }}
         go_version: ${{ inputs.go_version }}
         os: ${{ inputs.os }}


### PR DESCRIPTION
These changes fix the `test-verify` and `test-build` workflows.

The `test` workflow is [failing](https://github.com/hashicorp/actions-go-build/actions/runs/8993730360/job/24706017117#step:3:195) to run the super-linter.  Jeanne and I saw a similar `not in a git directory error` when trying to push BPA up to base image Alpine 3.19 (but it works fine under 3.12, breaks at 3.13).  In both cases, the job is running inside a docker container.  In my own BPA testing, I ran `docker run ...` directly from an inline script step in the job and did not see this error, maybe there's something about how the runner environment is connected to the docker environment that's broken.  My google-fu has failed me.