### PR TITLE
Nuke super-linter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,11 +10,6 @@ on:
       - "!action.yml"
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
 
   go-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Justification

~Bump the super-linter dep because it appears 6.8.0 is [broken](https://github.com/hashicorp/actions-go-build/actions/runs/15246873875/job/42875117920?pr=65#step:3:237).~
Removing the super-linter entirely, see last commit message.  We'll re-add linting later, this is currently blocking urgent work, we need a functional test suite.