### PR TITLE
Set valid directory in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,6 @@ updates:
           - minor
           - patch
   - package-ecosystem: gomod
-    directory:
+    directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION
### Justification

The repo's dependabot.yml has an invalid `directory` setting for the `gomod` ecosystem.  This PR fixes it.
