### PR TITLE
Update the Github actions to match the node.js 24  and update default go version from 1.17 &1.18.2 to 1.24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Dogfood this Action to build its own CLI.
       - uses: ./
         with:

--- a/.github/workflows/example-matrix.yml
+++ b/.github/workflows/example-matrix.yml
@@ -12,7 +12,7 @@ jobs:
           - { runner: ubuntu-latest, os: linux,   arch: arm64, env:  CGO_ENABLED=0 }
           - { runner: ubuntu-latest, os: windows, arch: amd64, env:  CGO_ENABLED=0 }
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build
         uses: hashicorp/actions-go-build@main
         with:

--- a/.github/workflows/example-matrix.yml.currentbranch.yml
+++ b/.github/workflows/example-matrix.yml.currentbranch.yml
@@ -13,7 +13,7 @@ jobs:
           - { runner: ubuntu-latest, os: linux,   arch: arm64, env:  CGO_ENABLED=0 }
           - { runner: ubuntu-latest, os: windows, arch: amd64, env:  CGO_ENABLED=0 }
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build
         uses: ./
         with:

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -4,7 +4,7 @@ jobs:
   example:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build
         uses: hashicorp/actions-go-build@main
         with:

--- a/.github/workflows/example.yml.currentbranch.yml
+++ b/.github/workflows/example.yml.currentbranch.yml
@@ -5,7 +5,7 @@ jobs:
   example:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build
         uses: ./
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Build CLI Binaries
         run: make release/zips
       - name: Create GitHub Release

--- a/.github/workflows/self-test-suite-verify.yml
+++ b/.github/workflows/self-test-suite-verify.yml
@@ -30,7 +30,7 @@ jobs:
           - { assert: failure, file: this-file-does-not-exist,            when: result file is missing }
           - { assert: failure, file: corrupt,                             when: result file is corrupt }
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # generate a random ID; GH doesn't provide a proper job ID (especially for matrix jobs)
       - name: Generate random ID to distinguish build artifacts
         run: echo "ARTIFACT_ID=$RANDOM" >> "$GITHUB_ENV"

--- a/.github/workflows/self-test-suite.yml
+++ b/.github/workflows/self-test-suite.yml
@@ -32,7 +32,7 @@ jobs:
           - { reproducible: report, want: success }
           - { reproducible: nope,   want: success }
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: select OS value
         run: case "${{ runner.os }}" in macOS) echo "SELECTED_OS=darwin" >> "$GITHUB_ENV" ;; Linux) echo "SELECTED_OS=linux" >> "$GITHUB_ENV" ;; esac
       - uses: ./self-test
@@ -57,7 +57,7 @@ jobs:
           - { reproducible: report, want: success }
           - { reproducible: nope,   want: success }
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: select OS value
         run: case "${{ runner.os }}" in macOS) echo "SELECTED_OS=darwin" >> "$GITHUB_ENV" ;; Linux) echo "SELECTED_OS=linux" >> "$GITHUB_ENV" ;; esac
       - uses: ./self-test
@@ -91,7 +91,7 @@ jobs:
           - { reproducible: report, os: darwin, arch: arm64, want: success }
           - { reproducible: nope,   os: darwin, arch: arm64, want: success }
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: runner.os == 'macOS'
       - uses: ./self-test
         if: runner.os == 'macOS'
@@ -117,7 +117,7 @@ jobs:
           - { reproducible: report, want: success }
           - { reproducible: nope,   want: success }
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: select OS value
         run: case "${{ runner.os }}" in macOS) echo "SELECTED_OS=darwin" >> "$GITHUB_ENV" ;; Linux) echo "SELECTED_OS=linux" >> "$GITHUB_ENV" ;; esac
       - uses: ./self-test
@@ -144,7 +144,7 @@ jobs:
           - { reproducible: report, want: success }
           - { reproducible: nope,   want: success }
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: select OS value
         run: case "${{ runner.os }}" in macOS) echo "SELECTED_OS=darwin" >> "$GITHUB_ENV" ;; Linux) echo "SELECTED_OS=linux" >> "$GITHUB_ENV" ;; esac
       - uses: ./self-test
@@ -170,7 +170,7 @@ jobs:
           - { reproducible: report, want: failure }
           - { reproducible: nope,   want: failure }
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: select OS value
         run: case "${{ runner.os }}" in macOS) echo "SELECTED_OS=darwin" >> "$GITHUB_ENV" ;; Linux) echo "SELECTED_OS=linux" >> "$GITHUB_ENV" ;; esac
       - uses: ./self-test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
   go-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           cache: false

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ that give the build some chance at being reproducible.
 
 ---
 
-Simplest Go 1.17 invocation. (Uses `-trimpath` to aid with reproducibility.)
+Simplest Go 1.24 invocation. (Uses `-trimpath` to aid with reproducibility.)
 
 ```yaml
 instructions: go build -o "$BIN_PATH" -trimpath

--- a/self-test/action.yml
+++ b/self-test/action.yml
@@ -32,7 +32,7 @@ inputs:
     required: false
   go_version:
     description: Passed through to action.
-    default: 1.17
+    default: 1.24
     required: false
   os:
     description: Passed through to action.

--- a/verify/testdata/valid-clean-reproducible.buildresult.json
+++ b/verify/testdata/valid-clean-reproducible.buildresult.json
@@ -16,7 +16,7 @@
       "SourceHash": "f4f4decfe74c8f4b241c3360069b36c75dd9da94"
     },
     "Parameters": {
-      "GoVersion": "1.18.2",
+      "GoVersion": "1.24",
       "Instructions": "go build -o \"$BIN_PATH\" -trimpath -buildvcs=false -ldflags \"-X 'github.com/hashicorp/actions-go-build/product.Repository=hashicorp/actions-go-build' -X 'github.com/hashicorp/actions-go-build/product.Module=github.com/hashicorp/actions-go-build' -X 'github.com/hashicorp/actions-go-build/product.Name=actions-go-build' -X 'github.com/hashicorp/actions-go-build/product.CoreName=actions-go-build' -X 'github.com/hashicorp/actions-go-build/product.ExecutableName=actions-go-build' -X 'github.com/hashicorp/actions-go-build/product.VersionFull=0.1.4' -X 'github.com/hashicorp/actions-go-build/product.VersionCore=0.1.4' -X 'github.com/hashicorp/actions-go-build/product.VersionMeta=' -X 'github.com/hashicorp/actions-go-build/product.Revision=f4f4decfe74c8f4b241c3360069b36c75dd9da94' -X 'github.com/hashicorp/actions-go-build/product.RevisionTime=2022-08-24T09:45:34Z' -X 'github.com/hashicorp/actions-go-build/product.SourceHash=f4f4decfe74c8f4b241c3360069b36c75dd9da94'\"",
       "OS": "darwin",
       "Arch": "arm64",


### PR DESCRIPTION
### Justification
Update the Github actions to match the node.js 24  and update default go version from 1.17 to 1.24

### Summary

Update default go version from 1.17 to 1.24, Resolves the 403 Forbidden error during legacy Go download on Apple Silicon runners.

Think about the potential reviewers and what they will need to know to perform a useful review.

### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
