### PR TITLE
SMRE-1028 : Update GitHub Actions dependencies to latest versions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
   steps:
 
     # Setup Go for CLI compilation.
-    - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: 1.24
         cache: false
@@ -109,7 +109,7 @@ runs:
       run: ./action-setup
 
     # Setup Go
-    - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+    - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         go-version: ${{ inputs.go_version }}
         cache: false
@@ -155,7 +155,7 @@ runs:
 
     # Upload Primary Build
     - name: Upload Primary Zip
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7.0.1
       with:
         name: ${{ env.ZIP_NAME }}
         path: ${{ env.ZIP_PATH_PRIMARY }}
@@ -171,7 +171,7 @@ runs:
     # Upload Local Verification Build
     - name: Upload Local Verification Zip
       if: inputs.reproducible == 'assert' || inputs.reproducible == 'report'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7.0.1
       with:
         name: ${{ env.ZIP_NAME }}.local-verification-build.zip
         path: ${{ env.ZIP_PATH_VERIFICATION }}
@@ -204,7 +204,7 @@ runs:
     # Upload Verification Result
     - name: Upload Verification Result
       if: inputs.reproducible == 'assert' || inputs.reproducible == 'report'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7.0.1
       with:
         name: ${{ env.ZIP_NAME }}.verificationresult.json
         path: ${{ env.VERIFICATION_RESULT }}


### PR DESCRIPTION
### Justification

Update GitHub Actions dependencies to latest versions

### Summary

This PR updates the GitHub Actions dependencies used in the actions-go-build workflow to their latest stable versions. The update includes:

- actions/setup-go: Updated to v6.4.0 (commit: 4a3601121dd01d1626a1e23e37211e3254c1c06c)
- actions/upload-artifact: Updated to v7.0.1 (commit: bbbca2ddaa5d8feaa63e36b76fdaad77386f024f)

These updates ensure the action benefits from the latest security patches, bug fixes, and performance improvements while maintaining compatibility with the existing reproducible Go build functionality.


### Quality

All changes to behavior should be accompanied by relevant tests which both document and protect it.

This PR includes:

  - [ ] New or updated tests which validate the new behavior.  _(Thank you!)_
  - [ ] New or updated behavior which has been manually tested. _(Please provide a link to relevant logs if this is the case.)_
  - [ ] New or updated behavior which is not testable in a reasonable time frame. _(Please ask for help if this is the case, more things are testable than we sometimes think!)_
  - [ ] No new or changed behavior.  _(Just documentation, configuration, or pure refactoring.)_
## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
